### PR TITLE
feat(tpl-terragrunt): add plan-gate job as stable required status check

### DIFF
--- a/.github/workflows/tpl-terragrunt.yaml
+++ b/.github/workflows/tpl-terragrunt.yaml
@@ -214,6 +214,22 @@ jobs:
           path: plan-summary.md
           if-no-files-found: warn
 
+  # Gate job with a stable, non-matrix name used as the required status check.
+  # Runs whenever action=plan, regardless of whether stacks were detected.
+  # Fails if any plan matrix job failed; passes otherwise (including skip = no iac changes).
+  plan-gate:
+    needs: [detect, plan]
+    if: ${{ always() && inputs.action == 'plan' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert plan succeeded
+        run: |
+          if [[ "${{ needs.plan.result }}" == "failure" ]]; then
+            echo "One or more plan jobs failed."
+            exit 1
+          fi
+          echo "Plan result: ${{ needs.plan.result }}"
+
   # Aggregates plan summaries from all matrix jobs into a single PR comment.
   # Runs even if some plan jobs failed so partial results are always visible.
   comment:


### PR DESCRIPTION
The matrix plan job reports as "plan / plan ({stack}, {slug})" which is stack-name-dependent and can't be used directly as a branch protection required check. The comment job always passes regardless of plan outcome.

plan-gate is a non-matrix job that:
- always runs when action=plan (even with no iac changes)
- fails if any plan matrix job failed
- passes if plan succeeded or was skipped (no iac changes)

Required status check in branch protection should be "plan / plan-gate".